### PR TITLE
correct path bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The only fields that are required are `tests` and `reports`. Each take an array 
   "krabby": {
     "tests": [ {
       "name": "jshint",
-      "files": ["./**/*.js", "!./node_module"],
+      "files": ["./**/*.js", "!./node_module/**/*"],
       "testConfig": {
         "browser": true
       }

--- a/tests/_baseTest.js
+++ b/tests/_baseTest.js
@@ -1,4 +1,4 @@
-var glob = require('globby');
+var globby = require('globby');
 var isGlob = require('is-glob');
 var _ = require('lodash');
 
@@ -16,7 +16,7 @@ function _BaseKeabbyTest(baseConfig) {
     };
 
     if (this.config.files && this.config.files.some(isGlob)) {
-      this.config.files = glob.sync(this.config.files, {nodir: true});
+      this.config.files = globby.sync(this.config.files, {nodir: true});
     }
   };
 


### PR DESCRIPTION
This corrects a bug where paths were not properly negated. A few notes on the implementation:

Passing an Array is undocumented behavior for glob which is why I chose to use an each loop
https://www.npmjs.com/package/glob#glob-pattern-options-cb

Negation is being removed from glob in it's current form. More importantly when parsed as 2 separate paths it doesn't negate anything at all.
https://www.npmjs.com/package/glob#negation
