### PR TITLE
Correct bad example config in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,38 @@ You pick and choose the tests that you want to use to test your code, and anothe
 ## why?
 When working with teams larger than just yourself, it is common for a number of different styles to emerge. Code that is totally fine with one person, may be completely unacceptable to another. As a result, it becomes harder and harder to be able to trust code that you yourself didn't write. This is where krabby shines! By creating your own `krabby.json` file, you can quickly get a detailed report on whether or not any piece of code is up to your standards.
 
-## how?
-Before anything else, you will need to install krabby.
+## Quick Start
 
-```
+Install Krabby
+
+```shell
 npm install -g krabby
 ```
 
-Next, you will need to create your configuration. This is just a simple JSON object representing the tests and reports that you wish to have run.
+Add config to either your package.json or a `krabby.json` file at the root of your project
 
+###### package.json
 ```json
 {
+  "name": "my-project",
+  "version": "1.0.0",
+
   "krabby": {
     "tests": [ "jshint" ],
     "reports": [ "badge" ]
   }
 }
 ```
+
+###### `krabby.json`
+```json
+{
+  "tests": [ "jshint" ],
+  "reports": [ "badge" ]
+}
+```
+
+## Config Reference
 
 The only fields that are required are `tests` and `reports`. Each take an array of either strings or objects. When it is a string, it means it will run the test by that name with it's default settings. If you wish to override the default settings (which you almost always should...), you just use an object instead.
 
@@ -57,15 +72,8 @@ The only thing that is actually _required_, the `name` parameter represents the 
 #### testConfig
 `testConfig` can be any data format (string, array, object, etc) but is almost always an object. It is the canonical way to pass configuration from your krabby configuration to an underlying library (e.g. the [jshint task](https://github.com/patrickkettner/krabby/blob/master/tests/jshint.js) passes this to the [jshint library](http://jshint.com/docs/))
 
-
-
-Since krabby tries to be as flexible as possible, you can place this configuration in a number of locations.
-
-#### package.json
-npm [encourages you](http://blog.npmjs.org/post/101775448305/npm-and-front-end-packaging) to package.json all the things. Therefore you can place your config inside a `package.json` file, and as long as krabby is ran from within the same project (meaning the folder the package.json file is in, or one of its child folders) krabby will automatically find and parse it.
-
-#### krabby.json
-if you don't want to add a new field to your package.json for some reason, you can also create a new files called `krabby.json` The same run-in-the-same-project rules from the `pacakge.json` apply here, too.
+#### package.json vs. krabby.json
+npm [encourages you](http://blog.npmjs.org/post/101775448305/npm-and-front-end-packaging) to package.json all the things. Therefore you can place your config inside a `package.json` file, and as long as krabby is run from within the same project (meaning the folder the package.json file is in, or one of its child folders) krabby will automatically find and parse it. If you don't want to add a new field to your package.json, you can create a `krabby.json` file at the root of your project. The same run-in-the-same-project rules from the `pacakge.json` apply here, too.
 
 #### --config
 `krabby` the command takes a `--config | -c` argument that lets you pass a filepath to a configuration file. This lets you maintain your own preferred `krabby.json` file that you can quickly and easily use to compare against any new code you come across.


### PR DESCRIPTION
This PR updates the docs to more clearly disambiguate what the config should look like in the package.json vs in a krabby.json file.
