### PR TITLE
Create a POC jsHint reporter to generate HTML with links to errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "license": "ISC",
   "dependencies": {
     "async": "^0.9.0",
+    "babel": "^5.1.10",
     "find-parent-dir": "^0.3.0",
     "globby": "^2.0.0",
     "is-glob": "^1.1.3",
     "jshint": "^2.6.3",
     "lodash": "^3.6.0",
+    "react": "^0.13.1",
     "yargs": "^3.7.0"
   }
 }

--- a/reports/jshint-lines-of-shame.js
+++ b/reports/jshint-lines-of-shame.js
@@ -1,0 +1,48 @@
+// TODO: We need to figure out whether React will be supported natively for a reporter or if they
+// will be required to pre-compile
+
+// All subsequent files required by node with the extensions .es6, .es, .jsx and .js
+// will be transformed by babel.
+require('babel/register');
+
+var _ = require('lodash');
+var React = require('react');
+
+// TODO: This reporter requires multiple files, it may be better to put each reporter in a
+// directory. This also brings to light a potential issue with using the file name as the reporter
+// name. What if a reporter exports an Object like `{name: 'jsHint', process: function () {...}}`?
+var Report = require('./jshint-lines-of-shame/shame-report.jsx');
+
+var formatData = function formatData (rawData) {
+  return _.map(rawData, function(file) {
+    var errors = _.map(file.errors, function(error) {
+      return _.pick(error, ['reason', 'code', 'line', 'character']);
+    });
+    return {
+      path: file.file,
+      errors: errors
+    };
+  });
+};
+
+module.exports = function(results, cb) {
+  // TODO: This is a bit cumbersome
+  var jsHintResults = _.find(results, function(result) {
+    return result.config.name === 'jshint';
+  });
+
+  // TODO: This format necessitates specific knowledge/exploration of each test you're consuming
+  // Since each test will produce dramatically different output maybe an Object would be better than
+  // an Array. This would also solve the cumbersome name issue above.
+  var data = formatData(jsHintResults.logs.errors);
+
+  // TODO: I am assuming this would be pulled in via the config object? Is this already possible?
+  var linkRoot ='https://gecgithub01.walmart.com/GlobalProducts/atlas-common/tree/master/frontend';
+
+  // TODO: We need to decide if the reporter itself is responsible for saving a file or if all
+  // reporters should output a string and let Krabby do the deed involving fs.
+  cb(React.renderToStaticMarkup(React.createElement(Report, {
+    data: data,
+    linkRoot: linkRoot
+  })));
+};

--- a/reports/jshint-lines-of-shame/shame-report.jsx
+++ b/reports/jshint-lines-of-shame/shame-report.jsx
@@ -1,0 +1,32 @@
+'use strict';
+
+var React = require('react');
+var _ = require('lodash');
+
+var Report = React.createClass({
+  createLinks: function() {
+    return _.map(this.props.data, function(file) {
+      return (
+        <div>
+          <h1>{file.path}</h1>
+          {
+            _.map(file.errors, function(error) {
+              // This doesn't generate a valid link - it is just a POC
+              return <a href={this.props.linkRoot + file.path}>{error.code + ': ' + error.reason}</a>;
+            }, this)
+          }
+        </div>
+      )
+    }, this);
+  },
+
+  render: function() {
+    return (
+      <section>
+        {this.createLinks()}
+      </section>
+    );
+  }
+});
+
+module.exports = Report;


### PR DESCRIPTION
This is a proof-of-concept PR to try to try to learn about how the reporter data might be consumed and to identify some of the questions we will have to address as we develop more sophisticated reports.

I took notes as I was moving in the form of TODOs. 
