### PR TITLE
Make extends in base classes non destructive + correct typo

### DIFF
--- a/reports/_baseReport.js
+++ b/reports/_baseReport.js
@@ -4,7 +4,7 @@ function _BaseKeabbyReporter(baseConfig, reporter) {
 
   var krabbyReporter = function(config) {
     var args = Array.prototype.slice.call(arguments);
-    this.config = _.extend(baseConfig, config);
+    this.config = _.extend({}, baseConfig, config);
 
     return reporter;
   };

--- a/tests/_baseTest.js
+++ b/tests/_baseTest.js
@@ -2,10 +2,10 @@ var globby = require('globby');
 var isGlob = require('is-glob');
 var _ = require('lodash');
 
-function _BaseKeabbyTest(baseConfig) {
+function _BaseKrabbyTest(baseConfig) {
 
   var krabbyTest = function(config) {
-    this.config = _.extend(baseConfig, config);
+    this.config = _.extend({}, baseConfig, config);
     this.grade = 1;
 
     this.logs = {
@@ -28,4 +28,4 @@ function _BaseKeabbyTest(baseConfig) {
 
 }
 
-module.exports = _BaseKeabbyTest;
+module.exports = _BaseKrabbyTest;


### PR DESCRIPTION
Using an empty object in the extend has the added benefit of preventing the module from crashing when `new _baseTest()` is called without a base config object.
