### PR TITLE
Enforce name attribute in config

### DIFF
--- a/lib/tests/_baseTest.js
+++ b/lib/tests/_baseTest.js
@@ -6,8 +6,12 @@ function _BaseKrabbyTest(baseConfig) {
 
   var krabbyTest = function(config) {
     this.config = _.merge({}, baseConfig, config);
-    this.grade = 1;
 
+    if (_.isUndefined(this.config.name)) {
+      throw new Error('no name defined for test')
+    }
+
+    this.grade = 1;
     this.logs = {
       errors: [],
       warnings: [],

--- a/lib/tests/complexity.js
+++ b/lib/tests/complexity.js
@@ -7,6 +7,7 @@ var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require("fs"));
 
 var baseConfig = {
+  name: "complexity",
   testConfig: {
   },
   files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']

--- a/lib/tests/jshint.js
+++ b/lib/tests/jshint.js
@@ -4,6 +4,7 @@ var Async = require('async');
 var FS = require('fs');
 
 var baseConfig = {
+  name: "jshint",
   testConfig: {
   },
   files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']

--- a/test/spec/lib/tests/_baseTest.spec.js
+++ b/test/spec/lib/tests/_baseTest.spec.js
@@ -3,14 +3,19 @@ var _baseTest = require('../../../../lib/tests/_baseTest.js');
 
 describe("tests/_baseTest", function () {
   describe('configuration', function() {
-    it('should create a config property when no config is passed in', function() {
+    it('should throw an Error when not given a name', function() {
       var FakeTester = _baseTest();
-      var fakeTester = new FakeTester();
+      var error = false;
 
-      assert(_.isEqual(fakeTester.config, {}));
+      try {
+        var fakeTester = new FakeTester();
+      } catch (e) {
+        error = true;
+      }
+      assert(error);
     });
     it('should create a config property when only runtimeConfig is passed in', function() {
-      var runtimeTestConfig = { runtime: true };
+      var runtimeTestConfig = { name: 'test', runtime: true };
 
       var FakeTester = _baseTest();
       var fakeTester = new FakeTester(runtimeTestConfig);
@@ -18,7 +23,7 @@ describe("tests/_baseTest", function () {
       assert(_.isEqual(fakeTester.config, runtimeTestConfig));
     });
     it('should create a config property when only baseConfig is passed in', function() {
-      var baseTestConfig = { base: true };
+      var baseTestConfig = { name: 'test', base: true };
 
       var FakeTester = _baseTest(baseTestConfig);
       var fakeTester = new FakeTester();
@@ -27,6 +32,7 @@ describe("tests/_baseTest", function () {
     });
     it('should not modify the config objects', function() {
       var baseTestConfig = {
+        name: 'test',
         base: true,
         deep: {
           common: "base",
@@ -51,6 +57,7 @@ describe("tests/_baseTest", function () {
     });
     it('should contain unique (deep) values from both dictionaries', function() {
       var baseTestConfig = {
+        name: 'test',
         base: true,
         deep: {
           common: "base",
@@ -75,13 +82,13 @@ describe("tests/_baseTest", function () {
   });
   describe('default test method', function() {
     it('should have a test method', function() {
-      var FakeTester = _baseTest();
+      var FakeTester = _baseTest({name: 'test'});
       var fakeTester = new FakeTester();
 
       assert(_.isFunction(fakeTester.test));
     });
     it('should throw an Error when executed', function() {
-      var FakeTester = _baseTest();
+      var FakeTester = _baseTest({name: 'test'});
       var fakeTester = new FakeTester();
 
       var error = false;


### PR DESCRIPTION
It would also be okay if name were inferred by the package name which until we start breaking this apart is the file name but we need to be able to determine what config came from what tester.

An alternative solution would be to start restructuring testers so that they look like npm packages and include some meta information in the config object that gets passed around.

```
lib/
  tests/
    jshint/
      index.js
    complexity/
      index.js
```
