### PR TITLE
Add path to complexity report

### DIFF
--- a/lib/tests/complexity.js
+++ b/lib/tests/complexity.js
@@ -20,7 +20,9 @@ ComplexityTest.prototype.analyze = function(files) {
   return Promise.map(files, function(fileName) {
     return fs.readFileAsync(fileName)
       .then(function(data) {
-        return escomplex.analyse(data.toString(), testConfig);
+        var results = escomplex.analyse(data.toString(), testConfig)
+        results.path = fileName
+        return results;
       })
       .catch(function(e) {
         e.fileName = fileName;


### PR DESCRIPTION
Knowing what file each report came from is key if you care about anything other than the summary.
