### PR TITLE
Actually make config available to reporters

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,47 +49,33 @@ if (!config) {
   throw new Error('you did\'t define any krabby reports. great job.');
 }
 
-tests = config.tests.map(function(test) {
-  var testName;
-  var config = {};
+var findPlugins = function(plugins, path, rootMethod) {
+  return plugins.map(function(plugin) {
+    var pluginName;
+    var config = {};
 
-  if (typeof test === 'string') {
-    testName = test;
-  } else {
-    testName = test.name;
-    config = test;
-  }
+    if (typeof plugin === 'string') {
+      pluginName = plugin;
+    } else {
+      pluginName = plugin.name;
+      config = plugin;
+    }
 
-  var Test = require(Path.join(__dirname, 'lib/tests', testName));
-  test = new Test(config);
+    var Plugin = require(Path.join(__dirname, path, pluginName));
+    plugin = new Plugin(config);
 
-  return test.test.bind(test);
-});
+    return plugin[rootMethod].bind(plugin);
+  });
+}
 
-reports = config.reports.map(function(report) {
-  var reportName;
-  var config = {};
-
-  if (typeof report === 'string') {
-    reportName = report;
-  } else {
-    reportName = report.name;
-    config = report;
-  }
-
-  Report = require(Path.join(__dirname, 'lib/reports', reportName));
-  report = new Report(config);
-
-  return report.report.bind(report);
-});
-
+tests = findPlugins(config.tests, 'lib/tests', "test");
+reports = findPlugins(config.reports, 'lib/reports', "report");
 
 var test = function(cb) {
   async.parallel(tests, function(err, results) {
     cb.apply(this, arguments);
   });
 };
-
 
 var report = function() {
   var args = Array.prototype.slice.call(arguments);

--- a/index.js
+++ b/index.js
@@ -47,27 +47,19 @@ if (!config) {
   throw new Error('you did\'t define any krabby reports. great job.');
 }
 
-var findPlugins = function(plugins, path, rootMethod) {
+var instantiatePlugins = function(plugins, path, rootMethod) {
   return plugins.map(function(plugin) {
-    var pluginName;
-    var config = {};
+    var pluginConfig = _.isString(plugin) ? { name: plugin } : plugin;
 
-    if (typeof plugin === 'string') {
-      pluginName = plugin;
-    } else {
-      pluginName = plugin.name;
-      config = plugin;
-    }
+    var Plugin = require(Path.join(__dirname, path, pluginConfig.name));
+    var pluginInstance = new Plugin(pluginConfig);
 
-    var Plugin = require(Path.join(__dirname, path, pluginName));
-    plugin = new Plugin(config);
-
-    return plugin[rootMethod].bind(plugin);
+    return pluginInstance[rootMethod].bind(pluginInstance);
   });
 }
 
 var test = function(cb) {
-  var tests = findPlugins(config.tests, 'lib/tests', "test");
+  var tests = instantiatePlugins(config.tests, 'lib/tests', "test");
 
   async.parallel(tests, function(err, results) {
     cb.apply(this, arguments);
@@ -75,7 +67,7 @@ var test = function(cb) {
 };
 
 var report = function() {
-  var reports = findPlugins(config.reports, 'lib/reports', "report");
+  var reports = instantiatePlugins(config.reports, 'lib/reports', "report");
 
   var args = Array.prototype.slice.call(arguments);
   var cb = args.pop();

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ var Path = require('path');
 var _ = require('lodash');
 var FS = require('fs');
 var parentDir;
-var reports;
-var tests;
 var config;
 var pkg;
 
@@ -68,16 +66,17 @@ var findPlugins = function(plugins, path, rootMethod) {
   });
 }
 
-tests = findPlugins(config.tests, 'lib/tests', "test");
-reports = findPlugins(config.reports, 'lib/reports', "report");
-
 var test = function(cb) {
+  var tests = findPlugins(config.tests, 'lib/tests', "test");
+
   async.parallel(tests, function(err, results) {
     cb.apply(this, arguments);
   });
 };
 
 var report = function() {
+  var reports = findPlugins(config.reports, 'lib/reports', "report");
+
   var args = Array.prototype.slice.call(arguments);
   var cb = args.pop();
 

--- a/index.js
+++ b/index.js
@@ -57,12 +57,10 @@ tests = config.tests.map(function(test) {
     testName = test;
   } else {
     testName = test.name;
-
     config = test;
   }
 
   var Test = require(Path.join(__dirname, 'lib/tests', testName));
-
   test = new Test(config);
 
   return test.test.bind(test);
@@ -79,10 +77,10 @@ reports = config.reports.map(function(report) {
     config = report;
   }
 
-  report = require(Path.join(__dirname, 'lib/reports', reportName));
-  report = report(config);
+  Report = require(Path.join(__dirname, 'lib/reports', reportName));
+  report = new Report(config);
 
-  return report;
+  return report.report.bind(report);
 });
 
 

--- a/lib/reports/_baseReport.js
+++ b/lib/reports/_baseReport.js
@@ -3,10 +3,11 @@ var _ = require('lodash');
 function _BaseKeabbyReporter(baseConfig, reporter) {
 
   var krabbyReporter = function(config) {
-    var args = Array.prototype.slice.call(arguments);
     this.config = _.merge({}, baseConfig, config);
+  };
 
-    return reporter;
+  krabbyReporter.prototype.report = function() {
+    throw new Error('no report defined for test');
   };
 
   return krabbyReporter;

--- a/lib/reports/badge.js
+++ b/lib/reports/badge.js
@@ -1,7 +1,9 @@
 var BaseKrabbyReport = require('./_baseReport');
 var baseConfig = {};
 
-function badge(results, cb) {
+var BadgeReport = new BaseKrabbyReport(baseConfig);
+
+BadgeReport.prototype.report = function badge(results, cb) {
   var grade = results.reduce(function(total, result) {
     return total + (result.grade || 0);
   }, 0);
@@ -24,4 +26,4 @@ function badge(results, cb) {
   cb(url += '.svg');
 }
 
-module.exports = new BaseKrabbyReport(baseConfig, badge);
+module.exports = BadgeReport;

--- a/lib/tests/_baseTest.js
+++ b/lib/tests/_baseTest.js
@@ -7,10 +7,6 @@ function _BaseKrabbyTest(baseConfig) {
   var krabbyTest = function(config) {
     this.config = _.merge({}, baseConfig, config);
 
-    if (_.isUndefined(this.config.name)) {
-      throw new Error('no name defined for test')
-    }
-
     this.grade = 1;
     this.logs = {
       errors: [],

--- a/lib/tests/complexity.js
+++ b/lib/tests/complexity.js
@@ -7,7 +7,6 @@ var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require("fs"));
 
 var baseConfig = {
-  name: "complexity",
   testConfig: {
   },
   files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']

--- a/lib/tests/jshint.js
+++ b/lib/tests/jshint.js
@@ -4,7 +4,6 @@ var Async = require('async');
 var FS = require('fs');
 
 var baseConfig = {
-  name: "jshint",
   testConfig: {
   },
   files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']

--- a/test/spec/lib/tests/_baseTest.spec.js
+++ b/test/spec/lib/tests/_baseTest.spec.js
@@ -3,19 +3,14 @@ var _baseTest = require('../../../../lib/tests/_baseTest.js');
 
 describe("tests/_baseTest", function () {
   describe('configuration', function() {
-    it('should throw an Error when not given a name', function() {
+    it('should create a config property when no config is passed in', function() {
       var FakeTester = _baseTest();
-      var error = false;
+      var fakeTester = new FakeTester();
 
-      try {
-        var fakeTester = new FakeTester();
-      } catch (e) {
-        error = true;
-      }
-      assert(error);
+      assert(_.isEqual(fakeTester.config, {}));
     });
     it('should create a config property when only runtimeConfig is passed in', function() {
-      var runtimeTestConfig = { name: 'test', runtime: true };
+      var runtimeTestConfig = { runtime: true };
 
       var FakeTester = _baseTest();
       var fakeTester = new FakeTester(runtimeTestConfig);
@@ -23,7 +18,7 @@ describe("tests/_baseTest", function () {
       assert(_.isEqual(fakeTester.config, runtimeTestConfig));
     });
     it('should create a config property when only baseConfig is passed in', function() {
-      var baseTestConfig = { name: 'test', base: true };
+      var baseTestConfig = { base: true };
 
       var FakeTester = _baseTest(baseTestConfig);
       var fakeTester = new FakeTester();
@@ -32,7 +27,6 @@ describe("tests/_baseTest", function () {
     });
     it('should not modify the config objects', function() {
       var baseTestConfig = {
-        name: 'test',
         base: true,
         deep: {
           common: "base",
@@ -57,7 +51,6 @@ describe("tests/_baseTest", function () {
     });
     it('should contain unique (deep) values from both dictionaries', function() {
       var baseTestConfig = {
-        name: 'test',
         base: true,
         deep: {
           common: "base",
@@ -82,13 +75,13 @@ describe("tests/_baseTest", function () {
   });
   describe('default test method', function() {
     it('should have a test method', function() {
-      var FakeTester = _baseTest({name: 'test'});
+      var FakeTester = _baseTest();
       var fakeTester = new FakeTester();
 
       assert(_.isFunction(fakeTester.test));
     });
     it('should throw an Error when executed', function() {
-      var FakeTester = _baseTest({name: 'test'});
+      var FakeTester = _baseTest();
       var fakeTester = new FakeTester();
 
       var error = false;


### PR DESCRIPTION
It turns out that #14 doesn't work without a little more massaging. This PR does 3 things:
1. It instantiates reports in the same way that tests are. This both keeps style consistent across the project and properly makes the config object available inside of a reporter.
2. I noticed that the config is passed to the reporter but only if the reporter is an object. By passing the config all the time I was able to remove the cumbersome name requirement from #28.
3. As a bonus the code to generate tests reports from the config is now identical so I was able to extract that into a new function and DRY it up nicely with a total of ~23% recution in the size of `index.js`.
