### PR TITLE
Get index.js under test

### DIFF
--- a/bin/krabby.js
+++ b/bin/krabby.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+var yargs = require('yargs');
+var krabby = require('..');
+var path = require('path');
+var _ = require('lodash');
+
+var argv = yargs
+  .alias('c', 'config')
+  .argv;
+
+krabby(_.isUndefined(argv.config) ? {} : require(path.resolve(argv.config)));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "main": "index.js",
-  "bin": "index.js",
+  "bin": "./bin/krabby.js",
   "scripts": {
     "test": "mocha --recursive --require test/setup.js test/spec"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "main": "index.js",
-  "bin": "./bin/krabby.js",
+  "bin": "./bin/krabby",
   "scripts": {
     "test": "mocha --recursive --require test/setup.js test/spec"
   },

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -1,0 +1,58 @@
+var _ = require('lodash');
+var krabby = require('../../index.js');
+var BaseTest = require('../../lib/tests/_baseTest.js')();
+
+describe('index.js', function() {
+  describe('_getOptions', function() {
+    it('returns a config Object identical to any valid one passed in', function() {
+      var options = {
+        tests: [],
+        reports: [],
+        'extra-option': true
+      };
+
+      var parsedOptions = krabby._getOptions(options);
+      assert(_.isEqual(options, parsedOptions));
+    });
+    it('throws an Error if config doesn\'t define an Array of tests', function() {
+      var options = {
+        reports: []
+      };
+
+      var threwError = false;
+      try {
+        krabby._getOptions(options);
+      } catch (e) {
+        threwError = true;
+        assert(Error.message = 'you did\'t define any krabby tests. great job.');
+      }
+      assert(threwError);
+    });
+    it('throws an Error if config doesn\'t define an Array of reports', function() {
+      var options = {
+        tests: []
+      };
+
+      var threwError = false;
+      try {
+        krabby._getOptions(options);
+      } catch (e) {
+        threwError = true;
+        assert(Error.message = 'you did\'t define any krabby reports. great job.');
+      }
+      assert(threwError);
+    });
+  });
+  describe('_instantiatePlugins', function() {
+    it('returns an Array of instantiated plugins');
+    it('instantiated plugins have a config property with a name attribute');
+  });
+  describe('_test', function() {
+    it('executes each test that is passed in');
+    it('calls the callback after each test is executed');
+  });
+  describe('_report', function() {
+    it('executes each report that is passed in');
+    it('calls the callback after each test is executed');
+  });
+});


### PR DESCRIPTION
Originally #32 but retargeted to be against master

The goal of this PR is to get `index.js` under test. To do this, I needed to make three specific changes:
1. Extract arg parsing into a separate file (`/bin/krabby.js`)
2. Wrap the remaining functionality (just the config extraction) in an atomic function
3. Expose all of the methods for testing via module.exports
