### PR TITLE
Update package.json to remove npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "name": "krabby",
   "version": "0.1.0",
-  "description": "",
+  "description": "A code conformance module runner",
   "main": "index.js",
-  "bin": "./bin/krabby",
+  "bin": "./bin/krabby.js",
   "scripts": {
     "test": "mocha --recursive --require test/setup.js test/spec"
   },
-  "author": "",
+  "homepage": "https://github.com/patrickkettner/krabby",
+  "bugs": {
+    "url": "https://github.com/patrickkettner/krabby/issues"
+  },
+  "repository": "git://github.com/patrickkettner/krabby.git",
+  "private": false,
   "license": "ISC",
   "dependencies": {
     "async": "^0.9.0",
@@ -25,7 +30,11 @@
     "sinon": "^1.14.1"
   },
   "krabby": {
-    "tests": ["jshint"],
-    "reports": ["badge"]
+    "tests": [
+      "jshint"
+    ],
+    "reports": [
+      "badge"
+    ]
   }
 }


### PR DESCRIPTION
This PR removes the following two npm warnings

```
npm WARN package.json krabby@0.1.0 No repository field.
npm WARN package.json krabby@0.1.0 No bin file found at ./bin/krabby
```
