### PR TITLE
Use extend to simplify plugin authorship

### DIFF
--- a/lib/reports/_baseReport.js
+++ b/lib/reports/_baseReport.js
@@ -1,16 +1,13 @@
 var _ = require('lodash');
 
-function _BaseKeabbyReporter(baseConfig, reporter) {
+var KrabbyReporter = function(config) {
+  this.config = _.merge({}, this.config, config);
+};
 
-  var krabbyReporter = function(config) {
-    this.config = _.merge({}, baseConfig, config);
-  };
+KrabbyReporter.prototype.report = function() {
+  throw new Error('no report defined for test');
+};
 
-  krabbyReporter.prototype.report = function() {
-    throw new Error('no report defined for test');
-  };
+KrabbyReporter.extend = require('simple-extend');
 
-  return krabbyReporter;
-}
-
-module.exports =  _BaseKeabbyReporter;
+module.exports = KrabbyReporter;

--- a/lib/reports/badge.js
+++ b/lib/reports/badge.js
@@ -1,29 +1,28 @@
 var BaseKrabbyReport = require('./_baseReport');
-var baseConfig = {};
 
-var BadgeReport = new BaseKrabbyReport(baseConfig);
+var BadgeReport = BaseKrabbyReport.extend({
+  report: function badge(results, cb) {
+    var grade = results.reduce(function(total, result) {
+      return total + (result.grade || 0);
+    }, 0);
+    var url = 'https://img.shields.io/badge/repo%20grade-';
 
-BadgeReport.prototype.report = function badge(results, cb) {
-  var grade = results.reduce(function(total, result) {
-    return total + (result.grade || 0);
-  }, 0);
-  var url = 'https://img.shields.io/badge/repo%20grade-';
+    grade = grade / results.length;
 
-  grade = grade / results.length;
+    if (grade <= 0.59) {
+      url += 'F-red';
+    } else if (grade <= 0.69) {
+      url += 'D-red';
+    } else if (grade <= 0.79) {
+      url += 'C-yellowgreen';
+    } else if (grade <= 0.89) {
+      url += 'B-green';
+    } else {
+      url += 'A-brightgreen';
+    }
 
-  if (grade <= 0.59) {
-    url += 'F-red';
-  } else if (grade <= 0.69) {
-    url += 'D-red';
-  } else if (grade <= 0.79) {
-    url += 'C-yellowgreen';
-  } else if (grade <= 0.89) {
-    url += 'B-green';
-  } else {
-    url += 'A-brightgreen';
+    cb(url += '.svg');
   }
-
-  cb(url += '.svg');
-}
+});
 
 module.exports = BadgeReport;

--- a/lib/tests/_baseTest.js
+++ b/lib/tests/_baseTest.js
@@ -2,32 +2,28 @@ var globby = require('globby');
 var isGlob = require('is-glob');
 var _ = require('lodash');
 
-function _BaseKrabbyTest(baseConfig) {
+var KrabbyTest = function(config) {
+  this.config = _.merge({}, this.config, config);
 
-  var krabbyTest = function(config) {
-    this.config = _.merge({}, baseConfig, config);
+  this.grade = 1;
+  this.files = [];
 
-    this.grade = 1;
-    this.files = [];
-
-    this.logs = {
-      errors: [],
-      warnings: [],
-      logs: [],
-      debug: []
-    };
-
-    if (this.config.files && this.config.files.some(isGlob)) {
-      this.config.files = globby.sync(this.config.files, {nodir: true});
-    }
+  this.logs = {
+    errors: [],
+    warnings: [],
+    logs: [],
+    debug: []
   };
 
-  krabbyTest.prototype.test = function() {
-    throw new Error('no test defined for test');
-  };
+  if (this.config.files && this.config.files.some(isGlob)) {
+    this.config.files = globby.sync(this.config.files, {nodir: true});
+  }
+};
 
-  return krabbyTest;
+KrabbyTest.prototype.test = function() {
+  throw new Error('no test defined for test');
+};
 
-}
+KrabbyTest.extend = require('simple-extend');
 
-module.exports = _BaseKrabbyTest;
+module.exports = KrabbyTest;

--- a/lib/tests/complexity.js
+++ b/lib/tests/complexity.js
@@ -1,66 +1,66 @@
 'use strict';
 
-var krabbyTest = require('./_baseTest');
+var BaseKrabbyTest = require('./_baseTest');
 var escomplex = require('escomplex-js');
 var _ = require('lodash');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require("fs"));
 
-var baseConfig = {
-  testConfig: {
+var ComplexityTest = BaseKrabbyTest.extend({
+  config: {
+    testConfig: {
+    },
+    files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']
   },
-  files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']
-};
 
-var ComplexityTest = new krabbyTest(baseConfig);
+  analyze: function(files) {
+    var testConfig = this.config.testConfig;
 
-ComplexityTest.prototype.analyze = function(files) {
-  var testConfig = this.config.testConfig;
-
-  return Promise.map(files, function(fileName) {
-    return fs.readFileAsync(fileName)
-      .then(function(data) {
-        var results = escomplex.analyse(data.toString(), testConfig)
-        results.path = fileName
-        return results;
-      })
-      .catch(function(e) {
-        e.fileName = fileName;
-        return e;
-      });
-  });
-};
-
-ComplexityTest.prototype.process = function(rawResults) {
-  var MAXIMUM_COMPLEXITY = 171;
-  var results = _.reject(rawResults, _.isError);
-
-  var complexitySum = _.sum(results, function(result) {
-    // Maintainability: logarithmic scale from -infinity to 171, calculated from the logical lines
-    // of code, the cyclomatix complexity and the Halstead effort. Higher is better.
-    // http://ieeexplore.ieee.org/xpl/login.jsp?tp=&arnumber=242525&url=http%3A%2F%2Fieeexplore.ieee.org%2Fiel2%2F435%2F6237%2F00242525.pdf%3Farnumber%3D242525
-    return result.maintainability;
-  });
-
-  return {
-    // TODO: Determine if this is an appropriate scoring method for logarithmic data
-    grade: complexitySum / results.length / MAXIMUM_COMPLEXITY,
-    raw: results,
-    errors: _.filter(rawResults, _.isError)
-  };
-};
-
-ComplexityTest.prototype.test = function(cb) {
-  var self = this;
-
-  this.analyze(this.config.files)
-    .then(this.process)
-    .then(function(results) {
-      self.logs.logs = self.logs.logs.concat(results.raw);
-      self.logs.debug = self.logs.debug.concat(results.errors);
-      self.grade = results.grade;
-      cb(null, self);
+    return Promise.map(files, function(fileName) {
+      return fs.readFileAsync(fileName)
+        .then(function(data) {
+          var results = escomplex.analyse(data.toString(), testConfig)
+          results.path = fileName
+          return results;
+        })
+        .catch(function(e) {
+          e.fileName = fileName;
+          return e;
+        });
     });
-};
+  },
+
+  process: function(rawResults) {
+    var MAXIMUM_COMPLEXITY = 171;
+    var results = _.reject(rawResults, _.isError);
+
+    var complexitySum = _.sum(results, function(result) {
+      // Maintainability: logarithmic scale from -infinity to 171, calculated from the logical lines
+      // of code, the cyclomatix complexity and the Halstead effort. Higher is better.
+      // http://ieeexplore.ieee.org/xpl/login.jsp?tp=&arnumber=242525&url=http%3A%2F%2Fieeexplore.ieee.org%2Fiel2%2F435%2F6237%2F00242525.pdf%3Farnumber%3D242525
+      return result.maintainability;
+    });
+
+    return {
+      // TODO: Determine if this is an appropriate scoring method for logarithmic data
+      grade: complexitySum / results.length / MAXIMUM_COMPLEXITY,
+      raw: results,
+      errors: _.filter(rawResults, _.isError)
+    };
+  },
+
+  test: function(cb) {
+    var self = this;
+
+    this.analyze(this.config.files)
+      .then(this.process)
+      .then(function(results) {
+        self.logs.logs = self.logs.logs.concat(results.raw);
+        self.logs.debug = self.logs.debug.concat(results.errors);
+        self.grade = results.grade;
+        cb(null, self);
+      });
+  }
+});
 
 module.exports = ComplexityTest;

--- a/lib/tests/coverageExcludes.js
+++ b/lib/tests/coverageExcludes.js
@@ -1,60 +1,58 @@
 'use strict';
 
-var krabbyTest = require('./_baseTest');
+var BaseKrabbyTest = require('./_baseTest');
 var _ = require('lodash');
 var fs = require("fs");
 var path = require('path');
 
-var baseConfig = {};
+var ComplexityTest = BaseKrabbyTest.extend({
+  getConfig: function(filePath) {
+    var fileExists = fs.lstatSync(filePath).isFile();
+    return fileExists ? require(filePath) : null;
+  },
 
-var ComplexityTest = new krabbyTest(baseConfig);
+  // Uses a binomial to decrease the score at a near exponential rate with full failure at 13 excludes
+  gradeResults: function(results) {
+    var MULTIPLIER = 7;
+    var EXPONENT = 1.25;
 
-ComplexityTest.prototype.getConfig = function(filePath) {
-  var fileExists = fs.lstatSync(filePath).isFile();
-  return fileExists ? require(filePath) : null;
-}
+    var excludes = _.chain(results)
+      .map(_.identity)
+      .flatten()
+      .value();
 
-// Uses a binomial to decrease the score at a near exponential rate with full failure at 13 excludes
-ComplexityTest.prototype.gradeResults = function(results) {
-  var MULTIPLIER = 7;
-  var EXPONENT = 1.25;
+    if (excludes.length === 0) { return 1; }
 
-  var excludes = _.chain(results)
-    .map(_.identity)
-    .flatten()
-    .value();
+    var dockedPoints = MULTIPLIER * excludes.length + Math.pow(1.25, excludes.length);
+    dockedPoints = dockedPoints > 100 ? 100 : dockedPoints;
+    return (100 - dockedPoints)/100;
+  },
 
-  if (excludes.length === 0) { return 1; }
-
-  var dockedPoints = MULTIPLIER * excludes.length + Math.pow(1.25, excludes.length);
-  dockedPoints = dockedPoints > 100 ? 100 : dockedPoints;
-  return (100 - dockedPoints)/100;
-}
-
-ComplexityTest.prototype.test = function(cb) {
-  if (_.isEmpty(this.config.track)) {
-    cb(new Error("No Track defined"));
-    return;
-  }
-
-  var tracks = _.isString(this.config.track) ? [this.config.track] : this.config.track;
-
-  var repoExcludes = _.map(tracks, function(track) {
-    var filePath = path.resolve(track, "atlas-project-config.js");
-    var config = this.getConfig(filePath);
-
-    if (config) {
-      return config.coverageExcludes || {}
-    } else {
-      this.logs.debug.push(new Error("File: " + filePath + "does not exist"));
-      return {};
+  test: function(cb) {
+    if (_.isEmpty(this.config.track)) {
+      cb(new Error("No Track defined"));
+      return;
     }
-  }, this);
-  repoExcludes = _.zipObject(tracks, repoExcludes);
 
-  this.logs.logs = repoExcludes;
-  this.grade = _.sum(repoExcludes, this.gradeResults);
-  cb(null, this);
-};
+    var tracks = _.isString(this.config.track) ? [this.config.track] : this.config.track;
+
+    var repoExcludes = _.map(tracks, function(track) {
+      var filePath = path.resolve(track, "atlas-project-config.js");
+      var config = this.getConfig(filePath);
+
+      if (config) {
+        return config.coverageExcludes || {}
+      } else {
+        this.logs.debug.push(new Error("File: " + filePath + "does not exist"));
+        return {};
+      }
+    }, this);
+    repoExcludes = _.zipObject(tracks, repoExcludes);
+
+    this.logs.logs = repoExcludes;
+    this.grade = _.sum(repoExcludes, this.gradeResults);
+    cb(null, this);
+  }
+});
 
 module.exports = ComplexityTest;

--- a/lib/tests/jshint.js
+++ b/lib/tests/jshint.js
@@ -1,76 +1,76 @@
-var krabbyTest = require('./_baseTest');
+var BaseKrabbyTest = require('./_baseTest');
 var jshint = require('jshint').JSHINT;
 var Async = require('async');
 var FS = require('fs');
 
-var baseConfig = {
-  testConfig: {
+var JSHintTest = BaseKrabbyTest.extend({
+  config: {
+    testConfig: {
+    },
+    files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']
   },
-  files: ['./**/*.js', '!./node_modules/**/*.js', '!./**/node_modules/**/*.js']
-};
 
-var JSHintTest = new krabbyTest(baseConfig);
+  lint: function(file, cb) {
+    var self = this;
 
-JSHintTest.prototype.lint = function(file, cb) {
-  var self = this;
+    FS.readFile(file, function(err, data) {
+      if (err) {
+        return cb(err);
+      }
 
-  FS.readFile(file, function(err, data) {
-    if (err) {
-      return cb(err);
-    }
+      var result = jshint(data.toString(), self.config.testConfig);
 
-    var result = jshint(data.toString(), self.config.testConfig);
+      if (!result) {
 
-    if (!result) {
+        self.logs.errors.push({
+          file: file,
+          errors: jshint.errors
+        });
+      }
 
-      self.logs.errors.push({
-        file: file,
-        errors: jshint.errors
-      });
-    }
-
-    cb(null, result);
-  });
-};
-
-JSHintTest.prototype.test = function(cb) {
-  var self = this;
-  var tests = this.config.files.map(function(file) {
-
-    return function(cb) {
-      self.lint(file, cb);
-    }.bind(self);
-  });
-
-  Async.parallel(tests, function(err, results) {
-    self.process.call(self, self, cb);
-  });
-};
-
-JSHintTest.prototype.process = function(results, cb) {
-  // lets be optimistic...
-  var grade = 1;
-
-  if (results.logs.errors.length > 0) {
-    // automatic F for failures, but at least they aren't failing so badly we
-    // have to actually give up
-    grade = Math.min(grade, 0.5);
-  }
-
-  var tooMany = results.logs.errors.some(function(errs) {
-    return errs.errors.some(function(err) {
-      // E043 === "too many errors"
-      return err && err.code === 'E043';
+      cb(null, result);
     });
-  });
+  },
 
-  if (tooMany) {
-    // oh - they are fialing that bad? Ok. Goose egg it is
-    grade = 0;
+  test: function(cb) {
+    var self = this;
+    var tests = this.config.files.map(function(file) {
+
+      return function(cb) {
+        self.lint(file, cb);
+      }.bind(self);
+    });
+
+    Async.parallel(tests, function(err, results) {
+      self.process.call(self, self, cb);
+    });
+  },
+
+  process: function(results, cb) {
+    // lets be optimistic...
+    var grade = 1;
+
+    if (results.logs.errors.length > 0) {
+      // automatic F for failures, but at least they aren't failing so badly we
+      // have to actually give up
+      grade = Math.min(grade, 0.5);
+    }
+
+    var tooMany = results.logs.errors.some(function(errs) {
+      return errs.errors.some(function(err) {
+        // E043 === "too many errors"
+        return err && err.code === 'E043';
+      });
+    });
+
+    if (tooMany) {
+      // oh - they are fialing that bad? Ok. Goose egg it is
+      grade = 0;
+    }
+
+    results.grade = grade;
+    cb(null, results);
   }
-
-  results.grade = grade;
-  cb(null, results);
-};
+});
 
 module.exports = JSHintTest;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jshint": "^2.6.3",
     "lodash": "^3.7.0",
     "mocha-lcov-reporter": "0.0.2",
+    "simple-extend": "^0.1.0",
     "yargs": "^3.7.0"
   },
   "devDependencies": {

--- a/test/spec/lib/reports/_baseReport.spec.js
+++ b/test/spec/lib/reports/_baseReport.spec.js
@@ -1,26 +1,22 @@
 var _ = require('lodash');
-var _baseReport = require('../../../../lib/reports/_baseReport.js');
+var BaseReport = require('../../../../lib/reports/_baseReport.js');
 
 describe("lib/reports/_baseReport.js", function () {
   describe('configuration', function() {
     it('should create a config property when no config is passed in', function() {
-      var FakeReporter = _baseReport();
-      var fakeReporter = new FakeReporter();
-
+      var fakeReporter = new BaseReport();
       assert(_.isEqual(fakeReporter.config, {}));
     });
     it('should create a config property when only runtimeConfig is passed in', function() {
       var runtimeTestConfig = { runtime: true };
-
-      var FakeReporter = _baseReport();
-      var fakeReporter = new FakeReporter(runtimeTestConfig);
+      var fakeReporter = new BaseReport(runtimeTestConfig);
 
       assert(_.isEqual(fakeReporter.config, runtimeTestConfig));
     });
     it('should create a config property when only baseConfig is passed in', function() {
       var baseTestConfig = { base: true };
 
-      var FakeReporter = _baseReport(baseTestConfig);
+      var FakeReporter = BaseReport.extend({ config: baseTestConfig });
       var fakeReporter = new FakeReporter();
 
       assert(_.isEqual(fakeReporter.config, baseTestConfig));
@@ -43,7 +39,7 @@ describe("lib/reports/_baseReport.js", function () {
       var baseTestConfigCopy = JSON.parse(JSON.stringify(baseTestConfig));
       var runtimeTestConfigCopy = JSON.parse(JSON.stringify(runtimeTestConfig));
 
-      var FakeReporter = _baseReport(baseTestConfig);
+      var FakeReporter = BaseReport.extend({ config:baseTestConfig });
       var fakeReporter = new FakeReporter(runtimeTestConfig);
 
       assert(_.isEqual(baseTestConfig, baseTestConfigCopy));
@@ -65,12 +61,22 @@ describe("lib/reports/_baseReport.js", function () {
         }
       };
 
-      var FakeReporter = _baseReport(baseTestConfig);
+      var FakeReporter = BaseReport.extend({ config: baseTestConfig });
       var fakeReporter = new FakeReporter(runtimeTestConfig);
 
       assert(fakeReporter.config.deep.common === "runtime");
       assert(fakeReporter.config.deep.bass === true);
       assert(fakeReporter.config.deep.runtime === true);
+    });
+  });
+  describe('default report method', function() {
+    it('should have a report method', function() {
+      var fakeReporter = new BaseReport();
+      assert(_.isFunction(fakeReporter.report));
+    });
+    it('should throw an Error when executed', function() {
+      var fakeReporter = new BaseReport();
+      assert.throws(fakeReporter.report, /no report defined for test/);
     });
   });
 });

--- a/test/spec/lib/tests/_baseTest.spec.js
+++ b/test/spec/lib/tests/_baseTest.spec.js
@@ -1,26 +1,23 @@
 var _ = require('lodash');
-var _baseTest = require('../../../../lib/tests/_baseTest.js');
+var BaseTest = require('../../../../lib/tests/_baseTest.js');
 
 describe("lib/tests/_baseTest.js", function () {
   describe('configuration', function() {
     it('should create a config property when no config is passed in', function() {
-      var FakeTester = _baseTest();
-      var fakeTester = new FakeTester();
+      var fakeTester = new BaseTest();
 
       assert(_.isEqual(fakeTester.config, {}));
     });
     it('should create a config property when only runtimeConfig is passed in', function() {
       var runtimeTestConfig = { runtime: true };
-
-      var FakeTester = _baseTest();
-      var fakeTester = new FakeTester(runtimeTestConfig);
+      var fakeTester = new BaseTest(runtimeTestConfig);
 
       assert(_.isEqual(fakeTester.config, runtimeTestConfig));
     });
     it('should create a config property when only baseConfig is passed in', function() {
       var baseTestConfig = { base: true };
 
-      var FakeTester = _baseTest(baseTestConfig);
+      var FakeTester = BaseTest.extend({ config: baseTestConfig });
       var fakeTester = new FakeTester();
 
       assert(_.isEqual(fakeTester.config, baseTestConfig));
@@ -43,7 +40,7 @@ describe("lib/tests/_baseTest.js", function () {
       var baseTestConfigCopy = JSON.parse(JSON.stringify(baseTestConfig));
       var runtimeTestConfigCopy = JSON.parse(JSON.stringify(runtimeTestConfig));
 
-      var FakeTester = _baseTest(baseTestConfig);
+      var FakeTester = BaseTest.extend({ config: baseTestConfig});
       var fakeTester = new FakeTester(runtimeTestConfig);
 
       assert(_.isEqual(baseTestConfig, baseTestConfigCopy));
@@ -65,7 +62,7 @@ describe("lib/tests/_baseTest.js", function () {
         }
       };
 
-      var FakeTester = _baseTest(baseTestConfig);
+      var FakeTester = BaseTest.extend({ config: baseTestConfig });
       var fakeTester = new FakeTester(runtimeTestConfig);
 
       assert(fakeTester.config.deep.common === "runtime");
@@ -75,22 +72,12 @@ describe("lib/tests/_baseTest.js", function () {
   });
   describe('default test method', function() {
     it('should have a test method', function() {
-      var FakeTester = _baseTest();
-      var fakeTester = new FakeTester();
-
+      var fakeTester = new BaseTest();
       assert(_.isFunction(fakeTester.test));
     });
     it('should throw an Error when executed', function() {
-      var FakeTester = _baseTest();
-      var fakeTester = new FakeTester();
-
-      var error = false;
-      try {
-        fakeTester.test()
-      } catch (e) {
-        error = true;
-      }
-      assert(error);
+      var fakeTester = new BaseTest();
+      assert.throws(fakeTester.test, /no test defined for test/);
     });
   });
 });


### PR DESCRIPTION
Change _baseReport and _baseTest to use extend for inheritance

Why:
- Improved developer ergonomics - It is a little easier to reason about an extend method + POJsO than explaining prototypes. 
- Simplify the abstraction - Currently Krabby uses a closure to capture the baseConfig (with the new keyword) which creates a brand new prototype. This is then used to create a new Class in the prototypal style. This seemed like it exposed a little more than was needed to a plugin author. I tried moving it to a factory to hide the object construction at first but just using extend proved cleaner.
- Improve testability - Using a single abstraction for object inheritance makes tests using `instanceof`now possible!

Original:

```
var BaseKrabbyReport = require('./_baseReport');

var myReport = new BaseKrabbyReport({});

myReport.prototype.report = function(results, cb) {
  cb("Yipee");
}

module.exports = BadgeReport;
```

New:

```
var BaseKrabbyReport = require('./_baseReport');

var myReport = BaseKrabbyReport.extend({
  // An optional base config object
  config: {},
  report: function (results, cb) {
    cb("Yipee");
  }
});

module.exports = BadgeReport;
```
